### PR TITLE
disable handlers in --check mode

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,13 @@
 ---
 # handlers file for bind9
 - name: restart bind
-  service: 
-      name: "bind9"
-      state: restarted
+  service:
+    name: "bind9"
+    state: restarted
+  when: not ansible_check_mode
 
 - name: reload bind
   service:
-      name: "bind9"
-      state: reloaded
+    name: "bind9"
+    state: reloaded
+  when: not ansible_check_mode


### PR DESCRIPTION
Do not try to restart bind in `--check` mode. Since 1) it is not supposed to be done and b) it will cause an error if bind has not been installed yet. 